### PR TITLE
fix ineffficiency and ensure compatibility with armadillo 9.700+

### DIFF
--- a/src/push.cpp
+++ b/src/push.cpp
@@ -14,7 +14,7 @@ List pushCpp(arma::vec v, List x, SEXP perm, arma::sp_mat adjacency, SEXP one_fo
   arma::vec xv(v);
   arma::vec co = xv;
   int n = xlist.size();
-  int nn = arma::nonzeros(adjacency).size();
+  int nn = adjacency.n_nonzero;
   int perms = as<int >(perm);
   bool one_form = as<bool >(one_forms);
   arma::mat res_vertices = arma::zeros(perms+1, n);


### PR DESCRIPTION
* Extracting non-zeros just to get the number of non-zeros is inefficient. It's faster to simply use the [`.n_nonzero`](http://arma.sourceforge.net/docs.html#attributes) attribute.
* This fix also ensures that the code is compatible with Armadillo 9.700+, where the [nonzeros()](http://arma.sourceforge.net/docs.html#nonzeros) function has been placed in the delayed ops framework.

CC: @eddelbuettel